### PR TITLE
HTTP 캐싱 & 압축 적용 실습

### DIFF
--- a/cache/src/main/java/com/example/GreetingController.java
+++ b/cache/src/main/java/com/example/GreetingController.java
@@ -11,7 +11,7 @@ import javax.servlet.http.HttpServletResponse;
 public class GreetingController {
 
     @GetMapping("/")
-    public String index() {
+    public String index(final HttpServletResponse response) {
         return "index";
     }
 

--- a/cache/src/main/java/com/example/GreetingController.java
+++ b/cache/src/main/java/com/example/GreetingController.java
@@ -11,7 +11,7 @@ import javax.servlet.http.HttpServletResponse;
 public class GreetingController {
 
     @GetMapping("/")
-    public String index(final HttpServletResponse response) {
+    public String index() {
         return "index";
     }
 

--- a/cache/src/main/java/com/example/cachecontrol/CacheInterceptor.java
+++ b/cache/src/main/java/com/example/cachecontrol/CacheInterceptor.java
@@ -1,0 +1,20 @@
+package com.example.cachecontrol;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.springframework.http.CacheControl;
+import org.springframework.http.HttpHeaders;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+public class CacheInterceptor implements HandlerInterceptor {
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
+        final String cacheControl = CacheControl
+                .noCache()
+                .cachePrivate()
+                .getHeaderValue();
+        response.addHeader(HttpHeaders.CACHE_CONTROL, cacheControl);
+        return true;
+    }
+}

--- a/cache/src/main/java/com/example/cachecontrol/CacheWebConfig.java
+++ b/cache/src/main/java/com/example/cachecontrol/CacheWebConfig.java
@@ -9,5 +9,7 @@ public class CacheWebConfig implements WebMvcConfigurer {
 
     @Override
     public void addInterceptors(final InterceptorRegistry registry) {
+        registry.addInterceptor(new CacheInterceptor())
+                .addPathPatterns("/");
     }
 }

--- a/cache/src/main/java/com/example/etag/EtagFilterConfiguration.java
+++ b/cache/src/main/java/com/example/etag/EtagFilterConfiguration.java
@@ -1,12 +1,18 @@
 package com.example.etag;
 
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.filter.ShallowEtagHeaderFilter;
 
 @Configuration
 public class EtagFilterConfiguration {
 
-//    @Bean
-//    public FilterRegistrationBean<ShallowEtagHeaderFilter> shallowEtagHeaderFilter() {
-//        return null;
-//    }
+    @Bean
+    public FilterRegistrationBean<ShallowEtagHeaderFilter> shallowEtagHeaderFilter() {
+        FilterRegistrationBean<ShallowEtagHeaderFilter> filterRegistrationBean
+                = new FilterRegistrationBean<>( new ShallowEtagHeaderFilter());
+        filterRegistrationBean.addUrlPatterns("/etag/*");
+        return filterRegistrationBean;
+    }
 }

--- a/cache/src/main/java/com/example/etag/EtagFilterConfiguration.java
+++ b/cache/src/main/java/com/example/etag/EtagFilterConfiguration.java
@@ -1,5 +1,7 @@
 package com.example.etag;
 
+import com.example.version.ResourceVersion;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -8,11 +10,14 @@ import org.springframework.web.filter.ShallowEtagHeaderFilter;
 @Configuration
 public class EtagFilterConfiguration {
 
+    @Autowired
+    private ResourceVersion version;
+
     @Bean
     public FilterRegistrationBean<ShallowEtagHeaderFilter> shallowEtagHeaderFilter() {
         FilterRegistrationBean<ShallowEtagHeaderFilter> filterRegistrationBean
                 = new FilterRegistrationBean<>( new ShallowEtagHeaderFilter());
-        filterRegistrationBean.addUrlPatterns("/etag/*");
+        filterRegistrationBean.addUrlPatterns("/etag/*", "/resources/" + version.getVersion() + "/*");
         return filterRegistrationBean;
     }
 }

--- a/cache/src/main/java/com/example/version/CacheBustingWebConfig.java
+++ b/cache/src/main/java/com/example/version/CacheBustingWebConfig.java
@@ -1,7 +1,9 @@
 package com.example.version;
 
+import java.time.Duration;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.CacheControl;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
@@ -20,6 +22,7 @@ public class CacheBustingWebConfig implements WebMvcConfigurer {
     @Override
     public void addResourceHandlers(final ResourceHandlerRegistry registry) {
         registry.addResourceHandler(PREFIX_STATIC_RESOURCES + "/" + version.getVersion() + "/**")
-                .addResourceLocations("classpath:/static/");
+                .addResourceLocations("classpath:/static/")
+                .setCacheControl(CacheControl.maxAge(Duration.ofDays(365)).cachePublic());
     }
 }

--- a/cache/src/main/resources/application.yml
+++ b/cache/src/main/resources/application.yml
@@ -1,2 +1,6 @@
 handlebars:
   suffix: .html
+server:
+  compression:
+    enabled: true
+    min-response-size: 10


### PR DESCRIPTION
## 학습목표
- HTTP를 활용하여 사이트의 성능을 개선할 수 있다.
- HTTP 캐싱과 압축을 적용할 수 있다.

## 학습 순서
- 테스트 코드로 HTTP 헤더를 검증하는 방법을 익힌다.
- HTTP 압축을 설정한다.
- HTTP 헤더에 Cache-Control를 적용하고 캐싱이 적용됐는지 확인한다.
- 캐시 무효화(Cache Busting)를 학습한다.

## 실습 단계
- 0단계 - 휴리스틱 캐싱 제거하기
- 1단계 - HTTP Compression 설정하기
- 2단계 - ETag/If-None-Match 적용하기
- 3단계 - 캐시 무효화(Cache Busting)

## 소감
개발을 할 때마다 브라우저가 자동으로 캐시해서 매번 그걸 삭제했던 경험이 있었습니다.
이번 기회에 http 캐시를 서버에서 어떻게 설정할 수 있는지 알게 되어서 좋았습니다.
그리고 캐시를 간단하게 헤더로 설정할 수 있다는 점이 신기했습니다.